### PR TITLE
Fix copyright headers in main branch

### DIFF
--- a/clearpath/gaia/clearpath.ruleset
+++ b/clearpath/gaia/clearpath.ruleset
@@ -1,3 +1,11 @@
+////////////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
+//
+// Use of this source code is governed by the MIT
+// license that can be found in the LICENSE.txt file
+// or at https://opensource.org/licenses/MIT.
+////////////////////////////////////////////////////
+
 #include <sstream>
 
 #include <gaia/logger.hpp>
@@ -95,7 +103,7 @@ ruleset clearpath_rule_examples
         gaia_log::app().info("Vertex {} is part of graph {}", v.id, v->graph.uuid);
     }
 
-   
+
     ////////////////////
     // Iterating through a 1:n relationship
     //
@@ -193,4 +201,3 @@ ruleset event_rule_example : serial_group()
         );
     }
 }
-

--- a/frequent_flyer/CMakeLists.txt
+++ b/frequent_flyer/CMakeLists.txt
@@ -1,10 +1,10 @@
-#############################################
-# Copyright (c) 2022 Gaia Platform LLC
+###################################################
+# Copyright (c) Gaia Platform LLC
 #
-# Use of this source code is governed by an MIT-style
+# Use of this source code is governed by the MIT
 # license that can be found in the LICENSE.txt file
 # or at https://opensource.org/licenses/MIT.
-#############################################
+###################################################
 
 cmake_minimum_required(VERSION 3.16)
 

--- a/frequent_flyer/src/frequent_flyer.cpp
+++ b/frequent_flyer/src/frequent_flyer.cpp
@@ -1,10 +1,10 @@
-/////////////////////////////////////////////
-// Copyright (c) 2022 Gaia Platform LLC
+////////////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
 //
-// Use of this source code is governed by an MIT-style
+// Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.txt file
 // or at https://opensource.org/licenses/MIT.
-/////////////////////////////////////////////
+////////////////////////////////////////////////////
 
 #include <chrono>
 #include <iostream>

--- a/frequent_flyer/src/frequent_flyer.ddl
+++ b/frequent_flyer/src/frequent_flyer.ddl
@@ -1,10 +1,10 @@
----------------------------------------------
--- Copyright (c) 2022 Gaia Platform LLC
+----------------------------------------------------
+-- Copyright (c) Gaia Platform LLC
 --
--- Use of this source code is governed by an MIT-style
+-- Use of this source code is governed by the MIT
 -- license that can be found in the LICENSE.txt file
 -- or at https://opensource.org/licenses/MIT.
----------------------------------------------
+----------------------------------------------------
 
 database frequent_flyer
 

--- a/frequent_flyer/src/frequent_flyer.ruleset
+++ b/frequent_flyer/src/frequent_flyer.ruleset
@@ -1,10 +1,10 @@
-/////////////////////////////////////////////
-// Copyright (c) 2022 Gaia Platform LLC
+////////////////////////////////////////////////////
+// Copyright (c) Gaia Platform LLC
 //
-// Use of this source code is governed by an MIT-style
+// Use of this source code is governed by the MIT
 // license that can be found in the LICENSE.txt file
 // or at https://opensource.org/licenses/MIT.
-/////////////////////////////////////////////
+////////////////////////////////////////////////////
 
 #include "gaia/logger.hpp"
 


### PR DESCRIPTION
Fixing the copyright notices in main. With slam2 being merged already, I'm not sure how to re-merge these changes, so I am now applying them directly to main.