### PR TITLE
Add Gaia .clang-tidy and .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,117 @@
+BasedOnStyle: LLVM
+UseCRLF: false
+UseTab: Never
+IndentWidth: 4
+ColumnLimit: 0
+# The following configuration encodes the BreakBeforeBraces Allman style
+# but for BeforeLambdaBody to allow one-liner lambdas.
+# See discussion here about customizing BreakBeforeBraces: https://reviews.llvm.org/D94906#2505095.
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# Align public/final/protected on the left.
+AccessModifierOffset: -4
+
+# From clang-format-11 there are more fine grained options for this setting.
+AlignOperands: DontAlign
+BreakBeforeBinaryOperators: All
+BreakBeforeTernaryOperators: true
+
+AllowAllConstructorInitializersOnNextLine: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+BreakConstructorInitializers: BeforeComma
+ConstructorInitializerIndentWidth: 4
+
+AllowShortFunctionsOnASingleLine: None
+# Merge lambda into a single line if argument of a function.
+AllowShortLambdasOnASingleLine: Inline
+# (clang-format-13) Align lambda body relative to the indentation level of the outer scope the lambda signature resides in.
+# LambdaBodyIndentation: OuterScope
+
+# If false, all arguments will either be all on the same line or will have one line each.
+BinPackArguments: true
+BinPackParameters: true
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+
+# Merge multiple #include blocks together and sort as one. Then split into groups based on category priority:
+# 1. Associated file header (XYZ.hpp)
+# 2. C system headers. (Priority: 1-2)
+# 3. C++ standard library headers (Priority: 5)
+# 4. Third party library headers (Priority: 10)
+# 5. Other project headers (Priority: 20-23 + 30)
+# Note this could break the code, read: https://stackoverflow.com/questions/37927553/can-clang-format-break-my-code
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Public internal Gaia headers.
+  - Regex: 'gaia\/internal\/'
+    Priority: 20
+    SortPriority: 21
+  # Public Gaia headers.
+  - Regex: 'gaia\/'
+    Priority: 21
+    SortPriority: 20
+  # Internal Gaia headers.
+  - Regex: 'gaia_internal\/'
+    Priority: 22
+  # Internal Gaia spdlog headers.
+  - Regex: 'gaia_spdlog\/'
+    Priority: 23
+  # Internal Gaia spdlog headers.
+  - Regex: 'gaia_spdlog_setup\/'
+    Priority: 23
+  # Third-party headers.
+  - Regex: '[flatbuffers|gtest|libexplain|llvm|pybind11|rocksdb|spdlog|tabulate]\/'
+    Priority: 10
+    SortPriority: 10
+  - Regex: 'backward'
+    Priority: 10
+    SortPriority: 11
+  - Regex: 'cpptoml'
+    Priority: 10
+    SortPriority: 12
+  - Regex: 'liburing'
+    Priority: 10
+    SortPriority: 13
+  - Regex: 'json\.hpp'
+    Priority: 10
+    SortPriority: 14
+  # C system headers.
+  - Regex: '^<.*\.h>'
+    Priority: 1
+  - Regex: 'cassert|cctype|cerrno|cfenv|cfloat|cinttypes|climits|clocale|cmath|csetjmp|csignal|cstdarg|cstddef|cstdint|cstdio|cstdlib|cstring|ctime|cuchar|cwchar|cwctype'
+    Priority: 2
+  # C++ library headers.
+  - Regex: '^<.*'
+    Priority: 5
+  # Component-only headers.
+  - Regex: '.*'
+    Priority: 30
+
+KeepEmptyLinesAtTheStartOfBlocks: true
+SpaceAfterCStyleCast: false
+ContinuationIndentWidth: 4
+AlignTrailingComments: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,78 @@
+# Complete list of checks: https://clang.llvm.org/extra/clang-tidy/checks/list.html
+Checks: '-*,
+clang-analyzer-*,
+performance-*,
+modernize-*,
+readability-identifier-naming,
+cppcoreguidelines-avoid-magic-numbers,
+cppcoreguidelines-macro-usage,
+cppcoreguidelines-narrowing-conversions,
+cppcoreguidelines-no-malloc,
+cppcoreguidelines-pro-type-cstyle-cast,
+cppcoreguidelines-pro-type-const-cast,
+google-readability-namespace-comments,
+google-default-arguments,
+google-explicit-constructor,
+google-runtime-operator,
+google-readability-casting,
+-performance-unnecessary-value-param,
+-modernize-use-trailing-return-type,
+-modernize-avoid-c-arrays,
+-modernize-concat-nested-namespaces,
+-modernize-use-using,
+-modernize-use-nodiscard
+'
+
+# TODO: headers are disabled for now, they produce too many warnings.
+#HeaderFilterRegex: "GaiaPlatform/production/.*inc/.*(hpp|inc|h)$"
+
+CheckOptions:
+  #  - { key: readability-identifier-naming.ClassSuffix,           value: _t } can't do this because of exceptions
+  - { key: readability-identifier-naming.PrivateMemberPrefix,             value: m_ }
+  - { key: readability-identifier-naming.StructSuffix,                    value: _t }
+  - { key: readability-identifier-naming.GlobalVariablePrefix,            value: g_ }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,            value: c_ }
+  - { key: readability-identifier-naming.ConstantPrefix,                  value: c_ }
+  - { key: readability-identifier-naming.ConstexprVariablePrefix,         value: c_ }
+  - { key: readability-identifier-naming.TypeTemplateParameterPrefix,     value: T_ }
+  - { key: readability-identifier-naming.AbstractClassCase,               value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,                       value: lower_case }
+  - { key: readability-identifier-naming.ClassConstantCase,               value: lower_case }
+  - { key: readability-identifier-naming.ClassMemberCase,                 value: lower_case }
+  - { key: readability-identifier-naming.ClassMethodCase,                 value: lower_case }
+  - { key: readability-identifier-naming.ConstantCase,                    value: lower_case }
+  - { key: readability-identifier-naming.ConstexprFunctionCase,           value: lower_case }
+  - { key: readability-identifier-naming.ConstexprMethodCase,             value: lower_case }
+  - { key: readability-identifier-naming.ConstexprVariableCase,           value: lower_case }
+  - { key: readability-identifier-naming.EnumCase,                        value: lower_case }
+  - { key: readability-identifier-naming.EnumConstantCase,                value: lower_case }
+  - { key: readability-identifier-naming.FunctionCase,                    value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase,              value: lower_case }
+  - { key: readability-identifier-naming.GlobalFunctionCase,              value: lower_case }
+  - { key: readability-identifier-naming.GlobalVariableCase,              value: lower_case }
+  - { key: readability-identifier-naming.InlineNamespaceCase,             value: lower_case }
+  - { key: readability-identifier-naming.LocalConstantCase,               value: lower_case }
+  - { key: readability-identifier-naming.LocalVariableCase,               value: lower_case }
+  - { key: readability-identifier-naming.MemberCase,                      value: lower_case }
+  - { key: readability-identifier-naming.ConstantMemberCase,              value: lower_case }
+  - { key: readability-identifier-naming.PublicMemberCase,                value: lower_case }
+  - { key: readability-identifier-naming.MethodCase,                      value: lower_case }
+  - { key: readability-identifier-naming.NamespaceCase,                   value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase,                   value: lower_case }
+  - { key: readability-identifier-naming.ConstantParameterCase,           value: lower_case }
+  - { key: readability-identifier-naming.ParameterPackCase,               value: lower_case }
+  - { key: readability-identifier-naming.PureFunctionCase,                value: lower_case }
+  - { key: readability-identifier-naming.PureMethodCase,                  value: lower_case }
+  - { key: readability-identifier-naming.StaticConstantCase,              value: lower_case }
+  - { key: readability-identifier-naming.StaticVariableCase,              value: lower_case }
+  - { key: readability-identifier-naming.StructCase,                      value: lower_case }
+  - { key: readability-identifier-naming.TemplateParameterCase,           value: lower_case }
+  - { key: readability-identifier-naming.TemplateTemplateParameterCase,   value: lower_case }
+  - { key: readability-identifier-naming.TemplateUsingCase,               value: lower_case }
+  - { key: readability-identifier-naming.TypeTemplateParameterCase,       value: lower_case }
+  - { key: readability-identifier-naming.TypedefCase,                     value: lower_case }
+  - { key: readability-identifier-naming.UnionCase,                       value: lower_case }
+  - { key: readability-identifier-naming.UsingCase,                       value: lower_case }
+  - { key: readability-identifier-naming.ValueTemplateParameterCase,      value: lower_case }
+  - { key: readability-identifier-naming.VariableCase,                    value: lower_case }
+  - { key: readability-identifier-naming.VirtualMethodCase,               value: lower_case }


### PR DESCRIPTION
Adding `.clang-tidy` and `.clang-format` at the root of the git repo to keep consistent formatting but not make it specific to nay particular example.